### PR TITLE
Initialize More Time button to display none

### DIFF
--- a/src/speed_focus_mode/web/sfm-bottom-bar.js
+++ b/src/speed_focus_mode/web/sfm-bottom-bar.js
@@ -117,7 +117,7 @@ function spdfShow() {
 }
 
 const spdfButtonHTML = `
-<td id="spdfControls" width="50" align="center" valign="top" class="stat">
+<td id="spdfControls" width="50" align="center" valign="top" class="stat" style="display:none;">
 <button title="Shortcut key: ${window.spdfHotkeyMoreTime}" onclick="spdfClearCurrentTimeout();">
   More time!
   <span id="spdfTime" class="stattxt"></span><br>


### PR DESCRIPTION
Fixes an issue with the button showing when enableMoreTimeButton is true and the "Automatically show answer" setting is set to zero

#### Description

After disabling the more time button I noticed that it was still showing up - but only on some of my decks. After investigating in anki, I quickly realized that the culprit was wether there was a value in the "Automatically show answer" timer setting. When it's set to 0, the more timer button is showing up always regardless of the setting.

To address this, I hid the button by default. The idea is that when spdfShow is called, it will correctly reset the display value to show it. This does work with my anki settings, although I don't claim to be an expert on the platform. (only trying this on mac) Honestly, there's probably a code bug somewhere in here with the spdfShow/Hide functions, but I couldn't find it.

Thank you for this addon! Sorry I didn't want to see your extra button lol



#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build (Anki 2.1.56)
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [ ] Windows, version:
  - [x] macOS, version: 13.1
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
